### PR TITLE
fix: [nuwa] broken download link 

### DIFF
--- a/dev/634.json
+++ b/dev/634.json
@@ -142,7 +142,7 @@
 			}
 		},
 		{
-			"device": "nuwa",
+			"device": "",
 			"name": {
 				"zh": "小米 13 Pro",
 				"en": "Xiaomi 13 Pro"
@@ -151,7 +151,7 @@
 				"os": "OS1.0.24.3.11.DEV",
 				"android": "14.0",
 				"release": "2024-03-15",
-				"recovery": "miui_NUWA_OS1.0.24.3.11.DEV_3d14e7e860_14.0",
+				"recovery": "miui_NUWA_OS1.0.24.3.11.DEV_3d14e7e860_14.0.zip",
 				"fastboot": ""
 			}
 		},

--- a/dev/634.json
+++ b/dev/634.json
@@ -142,7 +142,7 @@
 			}
 		},
 		{
-			"device": "",
+			"device": "nuwa",
 			"name": {
 				"zh": "小米 13 Pro",
 				"en": "Xiaomi 13 Pro"


### PR DESCRIPTION
update nuwa recovery file name

current download link: https://cdn-ota.azureedge.net/OS1.0.24.3.11.DEV/miui_NUWA_OS1.0.24.3.11.DEV_3d14e7e860_14.0

![image](https://github.com/HegeKen/HyperData/assets/31034782/129e336c-f190-4595-aa51-fb7e7abadd79)
